### PR TITLE
Use Kea for DHCPv4

### DIFF
--- a/nixosConfigurations/artichoke/default.nix
+++ b/nixosConfigurations/artichoke/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, inventory, ... }: {
   imports = [
     ./atftpd.nix
-    ./dhcpv6.nix
+    ./dhcp.nix
     ./dns.nix
     ./firewall.nix
     ./lan.nix

--- a/nixosConfigurations/artichoke/dhcp.nix
+++ b/nixosConfigurations/artichoke/dhcp.nix
@@ -3,6 +3,10 @@
     dhcp4 = {
       enable = true;
       settings = {
+        control-socket = {
+          socket-type = "unix";
+          socket-name = "/run/kea/kea-dhcp4.socket";
+        };
         reservations-global = false;
         reservations-in-subnet = true;
         reservations-out-of-pool = true;

--- a/nixosConfigurations/artichoke/dhcp.nix
+++ b/nixosConfigurations/artichoke/dhcp.nix
@@ -9,7 +9,7 @@ in
       settings = {
         control-socket = {
           socket-type = "unix";
-          socket-name = "/run/kea/kea-dhcp4.socket";
+          socket-name = "/var/run/kea/kea-dhcp4.sock";
         };
         option-def = [{
           name = "classless-static-routes";
@@ -38,12 +38,20 @@ in
                 }];
                 option-data = [
                   {
+                    name = "routers";
+                    data = toKeaArray [ hosts.${config.networking.hostName}.ipv4 ];
+                  }
+                  {
                     name = "domain-name-servers";
                     data = toKeaArray [ hosts.${config.networking.hostName}.ipv4 ];
                   }
                   {
                     name = "ntp-servers";
                     data = toKeaArray [ hosts.${config.networking.hostName}.ipv4 ];
+                  }
+                  {
+                    name = "domain-search";
+                    data = "home.arpa";
                   }
                   {
                     name = "domain-name";
@@ -89,7 +97,7 @@ in
       settings = {
         control-socket = {
           socket-type = "unix";
-          socket-name = "/run/kea/kea-dhcp6.socket";
+          socket-name = "/var/run/kea/kea-dhcp6.sock";
         };
         reservations-global = false;
         reservations-in-subnet = true;

--- a/nixosConfigurations/artichoke/dhcp.nix
+++ b/nixosConfigurations/artichoke/dhcp.nix
@@ -1,4 +1,8 @@
-{ config, lib, inventory, ... }: {
+{ config, lib, inventory, ... }:
+let
+  toKeaArray = data: lib.concatStringsSep "," data;
+in
+{
   services.kea = {
     dhcp4 = {
       enable = true;
@@ -35,11 +39,11 @@
                 option-data = [
                   {
                     name = "domain-name-servers";
-                    data = [ hosts.${config.networking.hostName}.ipv4 ];
+                    data = toKeaArray [ hosts.${config.networking.hostName}.ipv4 ];
                   }
                   {
                     name = "ntp-servers";
-                    data = [ hosts.${config.networking.hostName}.ipv4 ];
+                    data = toKeaArray [ hosts.${config.networking.hostName}.ipv4 ];
                   }
                   {
                     name = "domain-name";
@@ -47,7 +51,7 @@
                   }
                 ] ++ lib.optional (includeRoutesTo != [ ]) {
                   name = "classless-static-routes";
-                  data = map
+                  data = toKeaArray (map
                     (networkName:
                       let
                         dotToComma = data: lib.replaceStrings [ "." ] [ "," ] data;
@@ -57,7 +61,7 @@
                       in
                       "${toString otherNetworkCidr},${otherNetwork},${router}"
                     )
-                    includeRoutesTo;
+                    includeRoutesTo);
                 } ++ lib.optional (mtu != null) {
                   name = "interface-mtu";
                   data = network.mtu;
@@ -66,7 +70,7 @@
                   lib.mapAttrsToList
                     (_: host: {
                       hw-address = host.mac;
-                      ip-addresses = [ host.ipv4 ];
+                      ip-address = host.ipv4;
                     })
                     (lib.filterAttrs (_: host: host.dhcp) hosts);
               }

--- a/nixosConfigurations/artichoke/dhcp.nix
+++ b/nixosConfigurations/artichoke/dhcp.nix
@@ -1,5 +1,38 @@
 { config, lib, inventory, ... }: {
   services.kea = {
+    dhcp4 = {
+      enable = true;
+      settings = {
+        reservations-global = false;
+        reservations-in-subnet = true;
+        reservations-out-of-pool = true;
+        interfaces-config = {
+          interfaces = map
+            (name: config.systemd.network.networks.${name}.name)
+            [ "trusted" "iot" "work" "mgmt" ];
+        };
+        subnet4 = lib.flatten (map
+          (name:
+            with inventory.networks.${name}; [
+              {
+                interface = config.systemd.network.networks.${name}.name;
+                subnet = networkIPv4Cidr;
+                pools = [{
+                  pool = "${networkIPv4SignificantBits}.100 - ${networkIPv4SignificantBits}.200";
+                }];
+                reservations =
+                  lib.mapAttrsToList
+                    (_: host: {
+                      hw-address = host.mac;
+                      ip-addresses = [ host.ipv4 ];
+                    })
+                    (lib.filterAttrs (_: host: host.dhcp) hosts);
+              }
+            ]
+          )
+          [ "trusted" "iot" "work" "mgmt" ]);
+      };
+    };
     dhcp6 = {
       enable = true;
       settings = {

--- a/nixosConfigurations/artichoke/lan.nix
+++ b/nixosConfigurations/artichoke/lan.nix
@@ -15,7 +15,6 @@ let
         "${network.hosts.artichoke.ipv6.ula}/${toString network.ipv6Cidr}"
       ];
       IPv6AcceptRA = false;
-      DHCPServer = true;
       IPv6SendRA = true;
     };
     ipv6SendRAConfig = {
@@ -83,15 +82,6 @@ let
       )
       ++ lib.optional (network.mtu != null) "26:uint16:${toString network.mtu}";
     };
-    dhcpServerStaticLeases = lib.flatten
-      (lib.mapAttrsToList
-        (_: host: {
-          dhcpServerStaticLeaseConfig = {
-            MACAddress = host.mac;
-            Address = host.ipv4;
-          };
-        })
-        (lib.filterAttrs (_: host: host.dhcp) network.hosts));
   };
   trusted = mkInternalInterface inventory.networks.trusted;
   iot = mkInternalInterface inventory.networks.iot;

--- a/nixosConfigurations/artichoke/monitoring.nix
+++ b/nixosConfigurations/artichoke/monitoring.nix
@@ -59,10 +59,18 @@ in
     kea = {
       enable = true;
       controlSocketPaths = [
+        config.services.kea.dhcp4.settings.control-socket.socket-name
         config.services.kea.dhcp6.settings.control-socket.socket-name
       ];
     };
   };
+  # TODO(jared): remove this when PR https://github.com/NixOS/nixpkgs/pull/195760 is merged
+  systemd.services.prometheus-kea-exporter.serviceConfig.ExecStart = lib.mkForce ''
+    ${pkgs.prometheus-kea-exporter}/bin/kea-exporter \
+      --address ${config.services.prometheus.exporters.kea.listenAddress} \
+      --port ${toString config.services.prometheus.exporters.kea.port} \
+      ${lib.concatStringsSep " " config.services.prometheus.exporters.kea.controlSocketPaths}
+  '';
   nixpkgs.overlays = [
     (_: prev: {
       prometheus-kea-exporter = prev.prometheus-kea-exporter.overrideAttrs (_: {


### PR DESCRIPTION
- Start moving to kea for dhcpv4
- Add control socket for dhcp4
- Port DHCP options from systemd-networkd to kea
- Remove dead code
- Fix kea settings
- Add default route to option 121
- Fix no default gateway and kea exporter args
